### PR TITLE
Control Error Extentsion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 
 .pydevproject
 
+venv
+
 .env
 
 .settings

--- a/blueshed/micro/web/templates/api-tmpl.js
+++ b/blueshed/micro/web/templates/api-tmpl.js
@@ -95,7 +95,8 @@ Control.prototype._connect = function(){
 			}
 			if(this._promises[message.id]){
 				if(message.error){
-					var error_obj = new Error(message.error);
+					var error_obj = new Error(message.message);
+                    error_obj.status_code = message.status_code
 	                error_obj["original_payload"] = message;
 					this._promises[message.id].reject(error_obj);
 				} else {

--- a/blueshed/micro/web/templates/api-tmpl.js
+++ b/blueshed/micro/web/templates/api-tmpl.js
@@ -4,7 +4,7 @@ var docCookies = {
     if (!sKey) { return null; }
     var result = document.cookie.replace(new RegExp("(?:(?:^|.*;)\\s*" + encodeURIComponent(sKey).replace(/[\-\.\+\*]/g, "\\$&") + "\\s*\\=\\s*([^;]*).*$)|^.*$"), "$1") || null;
     if(result && escape !== false){
-    	result = decodeURIComponent(result);
+        result = decodeURIComponent(result);
     }
     return result;
   },
@@ -25,7 +25,7 @@ var docCookies = {
       }
     }
     if(escape !== false){
-    	sValue = encodeURIComponent(sValue);
+        sValue = encodeURIComponent(sValue);
     }
     document.cookie = encodeURIComponent(sKey) + "=" + sValue + sExpires + (sDomain ? "; domain=" + sDomain : "") + (sPath ? "; path=" + sPath : "") + (bSecure ? "; secure" : "");
     return true;
@@ -47,10 +47,10 @@ var docCookies = {
 };
 
 function Control(){
-	this._last_id = 0;
-	this._promises = {};
-	this._client_id = this._uid();
-	this._user = {%raw json_encode(current_user) %};
+    this._last_id = 0;
+    this._promises = {};
+    this._client_id = this._uid();
+    this._user = {%raw json_encode(current_user) %};
     this._pending_requests = [];
     this._send_timeout = null;
     this._broadcast = null;
@@ -58,73 +58,73 @@ function Control(){
 }
 
 Control.prototype.init = function(broadcast_callback, close_callback){
-	this._broadcast = broadcast_callback;
-	this._close = close_callback;
-	return this._connect();
+    this._broadcast = broadcast_callback;
+    this._close = close_callback;
+    return this._connect();
 };
 
 Control.prototype._connect = function(){
-	return new Promise(function(resolve,reject){
-		var ws = null;
-		var protocol = document.location.protocol == "https:"? "wss://" : "ws://";
-		var ws_url = '{{ ws_url }}';
-		if(! ws_url){
-			ws_url = protocol + document.domain + ":" + document.location.port + '/websocket';
-		}
-		try{
-			ws = new WebSocket(ws_url + "?client_id="+this._client_id);
-		}
-		catch(err){
-			reject(err);
-		}
-		ws.onopen = function(){
-			this._connection = ws;
-			this._flush_pending();
-			resolve('open');
-		}.bind(this);
-		ws.onmessage = function(evt){
-			var message = JSON.parse(evt.data);
-			if(message.cookie){
-	            var expires = new Date();
-	            expires.setMonth(expires.getMonth() + 1);
-	            docCookies.setItem(message.cookie_name,
-	            		message.cookie, expires.toGMTString(),'/',document.domain,null,false);
-	            if(this._broadcast){
-	            	this._broadcast('MICRO_COOKIE_SET', message.result);
-	            }
-			}
-			if(this._promises[message.id]){
-				if(message.error){
-					var error_obj = new Error(message.message);
+    return new Promise(function(resolve,reject){
+        var ws = null;
+        var protocol = document.location.protocol == "https:"? "wss://" : "ws://";
+        var ws_url = '{{ ws_url }}';
+        if(! ws_url){
+            ws_url = protocol + document.domain + ":" + document.location.port + '/websocket';
+        }
+        try{
+            ws = new WebSocket(ws_url + "?client_id="+this._client_id);
+        }
+        catch(err){
+            reject(err);
+        }
+        ws.onopen = function(){
+            this._connection = ws;
+            this._flush_pending();
+            resolve('open');
+        }.bind(this);
+        ws.onmessage = function(evt){
+            var message = JSON.parse(evt.data);
+            if(message.cookie){
+                var expires = new Date();
+                expires.setMonth(expires.getMonth() + 1);
+                docCookies.setItem(message.cookie_name,
+                        message.cookie, expires.toGMTString(),'/',document.domain,null,false);
+                if(this._broadcast){
+                    this._broadcast('MICRO_COOKIE_SET', message.result);
+                }
+            }
+            if(this._promises[message.id]){
+                if(message.error){
+                    var error_obj = new Error(message.message);
                     error_obj.status_code = message.status_code
-	                error_obj["original_payload"] = message;
-					this._promises[message.id].reject(error_obj);
-				} else {
-					this._promises[message.id].resolve(message.result);
-				}
-				delete this._promises[message.id];
-			} else if(message.signal, this._broadcast){
-				this._broadcast(message.signal, message.message);
-			} else {
-				console.log(message);
-			}
-		}.bind(this);
-		ws.onclose = function(){
-			this._connection = null;
-			setTimeout(function(){
-				if(this._close){
-					this._close("closed");
-				} else {
-					location.reload(true);
-				}
-			}.bind(this), 200);
-		}.bind(this);
-		ws.onerror = function(err){
-			if(!this._connection){
-				reject(new Error(err.code || 'unknown error'));
-			}
-		}.bind(this);
-	}.bind(this));
+                    error_obj["original_payload"] = message;
+                    this._promises[message.id].reject(error_obj);
+                } else {
+                    this._promises[message.id].resolve(message.result);
+                }
+                delete this._promises[message.id];
+            } else if(message.signal, this._broadcast){
+                this._broadcast(message.signal, message.message);
+            } else {
+                console.log(message);
+            }
+        }.bind(this);
+        ws.onclose = function(){
+            this._connection = null;
+            setTimeout(function(){
+                if(this._close){
+                    this._close("closed");
+                } else {
+                    location.reload(true);
+                }
+            }.bind(this), 200);
+        }.bind(this);
+        ws.onerror = function(err){
+            if(!this._connection){
+                reject(new Error(err.code || 'unknown error'));
+            }
+        }.bind(this);
+    }.bind(this));
 };
 
 Control.prototype._uid = function(){
@@ -138,27 +138,27 @@ Control.prototype._uid = function(){
 Control.prototype._flush_pending = function(){
     this._send_timeout = null;
     this._connection.send(JSON.stringify({requests: this._pending_requests}));
-	this._pending_requests.length=0;
+    this._pending_requests.length=0;
 };
 
 Control.prototype._send = function(action, args) {
-	var id = this._client_id + ":"+ ++this._last_id;
-	return new Promise(function(resolve,reject){
-		this._pending_requests.push([id,action,args]);
+    var id = this._client_id + ":"+ ++this._last_id;
+    return new Promise(function(resolve,reject){
+        this._pending_requests.push([id,action,args]);
         if (!this._send_timeout && this._connection) {
             this._send_timeout = setTimeout(this._flush_pending.bind(this), 0);
         }
-		this._promises[id] = { reject: reject, resolve: resolve };
-	}.bind(this));
+        this._promises[id] = { reject: reject, resolve: resolve };
+    }.bind(this));
 };
 
 {% for service in services %}
 {% if service.docs and handler.settings.get('debug') is True %}/**
-	{{ service.docs }}
+    {{ service.docs }}
 **/{% end %}
 Control.prototype.{{ service.name }} = function({{ ", ".join([p.name for p in service.desc.parameters.values() if p.name[0] != '_' and p.name != 'context']) }}){
-	return this._send("{{ service.name }}", {
-		{{ ",\n\t\t".join(["{0!r}: {0} {1}".format(p.name,'|| ' + json_encode(p.default) if p.default is not p.empty else '') for p in service.desc.parameters.values() if p.name[0] != '_' and p.name != 'context']) }}
-	});
+    return this._send("{{ service.name }}", {
+        {{ ",\n\t\t".join(["{0!r}: {0} {1}".format(p.name,'|| ' + json_encode(p.default) if p.default is not p.empty else '') for p in service.desc.parameters.values() if p.name[0] != '_' and p.name != 'context']) }}
+    });
 };
 {% end %}


### PR DESCRIPTION
Wasn't able to get display error for users from current exception so I fiddled.

Switched JS Error to use `message` - instead of `error` value - and added `status_code` property.

This does change previous behaviour - things that would have displayed some HTTP Error string like 'XXX Http Error Name' will now display either the stack trace or 'cripes'/`reason`.

Could have only appended to the JS `Error` object with `status_code` and `display_message` but thought that this is a better option as it reflects Micros error instead of switching variable names (mapping error to Error object's message property):

Micro: context_mixin.py

``` python
micro_error = {
    'id': context.action_id,
    'action': context.action,
    'result': None,
    'status_code': code,
    'error': error,
    'message': message,
}
```

Control: control.js

``` javascript
previous_js_error = {
    message: micro_error.error,
}
proposed_js_error = {
    message: micro_error.message,
    status_code: micro_error.status_code,
}
```

Could also add back in `error` property or the other micro_error properties if it's needed.
